### PR TITLE
Fix notice for unused var in `load_plugin_textdomain`

### DIFF
--- a/wp-includes/l10n.php
+++ b/wp-includes/l10n.php
@@ -721,9 +721,6 @@ function load_plugin_textdomain( $domain, $plugin_rel_path = false ) {
 
 	if ( false !== $plugin_rel_path ) {
 		$path = WP_PLUGIN_DIR . '/' . trim( $plugin_rel_path, '/' );
-	} elseif ( false !== $deprecated ) {
-		_deprecated_argument( __FUNCTION__, 'WP-2.7.0' );
-		$path = ABSPATH . trim( $deprecated, '/' );
 	} else {
 		$path = WP_PLUGIN_DIR;
 	}


### PR DESCRIPTION
`$default` was removed from `load_plugin_textdomain` parameters but used inside the function.