### PR TITLE
Remove reference to locate_block_template() in comment

### DIFF
--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -435,8 +435,6 @@ function get_privacy_policy_template() {
 /**
  * Retrieves path of page template in current or parent template.
  *
- * Note: For block themes, use locate_block_template function instead.
- *
  * The hierarchy for this template looks like:
  *
  * 1. {Page Template}.php


### PR DESCRIPTION
Docblock for get_page_template() contained a reference to locate_block_template().

This has been removed.
