### PR TITLE
Cleanup Plugin/Themes install screens

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - develop
-  pull_request:
-    branches:
-      - main
 
 env:
   PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}

--- a/src/js/_enqueues/wp/theme.js
+++ b/src/js/_enqueues/wp/theme.js
@@ -2042,7 +2042,8 @@ themes.RunInstaller = {
 		themes.router.on( 'route:sort', function( sort ) {
 			if ( ! sort ) {
 				sort = 'popular';
-				themes.router.navigate( themes.router.baseUrl( '?browse=popular' ), { replace: true } );
+				// Commented out, the popular section is disabled on WP CMS
+				// themes.router.navigate( themes.router.baseUrl( '?browse=popular' ), { replace: true } );
 			}
 			self.view.sort( sort );
 

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -132,6 +132,11 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		 */
 		$tabs = apply_filters( 'install_plugins_tabs', $tabs );
 
+		// For now, reset the $tabs array to only contain the search results tab
+		// I don't want to destroy the tabs functionality just yet, but if I do it, make sure to clean up everything
+		$tabs = array();
+		$tabs['search'] = __( 'Search Results' );
+
 		/**
 		 * Filters tabs not associated with a menu item on the Add Plugins screen.
 		 *

--- a/src/wp-admin/includes/class-wp-theme-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-theme-install-list-table.php
@@ -85,6 +85,12 @@ class WP_Theme_Install_List_Table extends WP_Themes_List_Table {
 			$tab = key( $tabs );
 		}
 
+		// For now, reset the $tabs array to only contain the search results tab
+		// I don't want to destroy the tabs functionality just yet, but if I do it, make sure to clean up everything
+		unset($tabs);
+		$tabs = array();
+		$tabs['search'] = __( 'Search Results' );
+
 		$args = array(
 			'page'     => $paged,
 			'per_page' => $per_page,

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -627,6 +627,7 @@ function themes_api( $action, $args = array() ) {
 	if( isset( $res->themes ) and is_array( $res->themes ) ) {
 		$whitelist_of_slugs = array(
 			'yuma-blogger',
+			'classic-coffee-shop',
 		);
 		$whitelisted_themes = array();
 		foreach ( $res->themes as $theme ) {

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -194,18 +194,11 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 	<h2 class="screen-reader-text hide-if-no-js"><?php _e( 'Filter themes list' ); ?></h2>
 
 	<div class="wp-filter hide-if-no-js">
-		<div class="filter-count">
+		<div class="filter-count" style="display: none;">
 			<span class="count theme-count"></span>
 		</div>
 
-		<ul class="filter-links">
-			<li><a href="#" data-sort="popular"><?php _ex( 'Popular', 'themes' ); ?></a></li>
-			<li><a href="#" data-sort="new"><?php _ex( 'Latest', 'themes' ); ?></a></li>
-			<li><a href="#" data-sort="block-themes"><?php _ex( 'Block Themes', 'themes' ); ?></a></li>
-			<li><a href="#" data-sort="favorites"><?php _ex( 'Favorites', 'themes' ); ?></a></li>
-		</ul>
-
-		<button type="button" class="button drawer-toggle" aria-expanded="false"><?php _e( 'Feature Filter' ); ?></button>
+		<button type="button" class="button drawer-toggle" aria-expanded="false" style="display: none;"><?php _e( 'Feature Filter' ); ?></button>
 
 		<form class="search-form"></form>
 
@@ -267,7 +260,13 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 	<div class="theme-browser content-filterable"></div>
 	<div class="theme-install-overlay wp-full-overlay expanded"></div>
 
-	<p class="no-themes"><?php _e( 'No themes found. Try a different search.' ); ?></p>
+	<p class="no-themes">
+		<b><?php _e( 'Use the search box' ); ?></b><br><br>
+		<?php _e( 'Note that only compatible WordPress themes will show up.' ); ?><br><br>
+		<?php _e( 'If you are using WP CMS, you are encouraged to build your own theme to cover your own needs anyway.' ); ?><br><br>
+		<?php _e( 'Prebuilt themes are like precooked food: usually a piece of shit.' ); ?>
+	</p>
+
 	<span class="spinner"></span>
 
 <?php


### PR DESCRIPTION
Blocks will inevitably cause issues. Having the directory show Plugins and Themes which will cause issues is a stupid thing to do. That's why Themes and Plugins now need to be on a whitelist for them to show up in the directory.

They can still be installed manually, of course. But having a bloated screen with Popular, Recommended, Whatever... plugins and themes is pointless.

If you tested some plugin or theme and think it should be on the whitelist, just add it and open a PR.
